### PR TITLE
add list module without polymorphic compare

### DIFF
--- a/src/monomorphic.ml
+++ b/src/monomorphic.ml
@@ -41,3 +41,11 @@ end
 
 module Int = Make(struct type t = int end)
 module Float = Make(struct type t = float end)
+
+type 'a eq = 'a -> 'a -> bool
+module List = struct
+  include List
+  let mem a ~f xs  = xs |> List.exists (f a)
+  let assoc a ~f xs = xs |> List.find (fun (k,_) -> f a k) |> snd
+  let mem_assoc a ~f xs = xs |> List.exists (fun (k, _) -> f k a)
+end

--- a/src/monomorphic.mli
+++ b/src/monomorphic.mli
@@ -54,3 +54,11 @@ module Int : module type of Make(struct type t = int end)
 
 (** Specialize functions with [float] *)
 module Float : module type of Make(struct type t = float end)
+
+type 'a eq = 'a -> 'a -> bool
+module List : sig
+  include module type of List
+  val mem : 'a -> f:'a eq -> 'a list -> bool
+  val assoc : 'k -> f:'k eq -> ('k * 'a) list -> 'a
+  val mem_assoc : 'k -> f:'k eq -> ('k * _) list -> bool
+end


### PR DESCRIPTION
Took a stab at List. Is this interface ok?

the way you'd use it would be:

`module List = Monomorphic.List`
